### PR TITLE
Use aggregation for order total

### DIFF
--- a/Website/market/catalog/models.py
+++ b/Website/market/catalog/models.py
@@ -1,5 +1,8 @@
 # catalog/models.py
-from django.db import models      #  ←  missing line
+from decimal import Decimal
+
+from django.db import models
+from django.db.models import F, Sum
 
 class Product(models.Model):
     sku   = models.CharField(max_length=32, unique=True)
@@ -18,7 +21,11 @@ class Order(models.Model):
 
     @property
     def total(self):
-        return sum(i.subtotal for i in self.items.all())
+        return (
+            self.items.aggregate(total=Sum(F("qty") * F("price")))
+            ["total"]
+            or Decimal("0")
+        )
 
 
 class OrderItem(models.Model):


### PR DESCRIPTION
## Summary
- add Decimal, F, and Sum imports for order aggregation
- calculate order totals with a database-level Sum over quantity and price

## Testing
- python -m compileall Website/market/catalog/models.py

------
https://chatgpt.com/codex/tasks/task_e_68c9437fa84883279daab7e58623bc3c